### PR TITLE
Force absolute source_path

### DIFF
--- a/walk-packages-for-changelog.py
+++ b/walk-packages-for-changelog.py
@@ -324,7 +324,8 @@ def main():
     parser.add_argument(
         'source_path',
         help='The top-level of the source tree in which to find packages',
-        action='store')
+        action='store',
+        type=os.path.abspath)
     parser.add_argument(
         'since',
         help='The ros2.repos file to generate documentation since',


### PR DESCRIPTION
Simple fix.

Allows providing a relative `source_path` without breaking the `url_path` logic. See https://github.com/clalancette/ros_changelog_from_pkgs/pull/2.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>